### PR TITLE
Fix schedule table alignment

### DIFF
--- a/events.html
+++ b/events.html
@@ -20,115 +20,54 @@
             <h2 style="text-align: center; color: #538F9F; font-size: larger;">Schedule & Events</h2>
             <table class="content-table">
                 <tr>
-                    <th></th>
-                    <th>The Schedule & Events page will continue to be updated as we get closer to the wedding date. In the meantime, see below for a high level breakdown of the celebrations.</th>
+                    <th colspan="2">The Schedule & Events page will continue to be updated as we get closer to the wedding date. In the meantime, see below for a high level breakdown of the celebrations.</th>
                 </tr>
                 <tr>
-                    <td><center><img src="icons/27august2025.png" alt="August 27 schedule icon"
-                        style="width: 200px; margin-right: 5px; vertical-align: middle;"></center></td></tr>
-                        <tr><td><center><b>
-                        Early <br>
-                        . <br>
-                        . <br>
-                        . <br>
-                        15:00 <br>
-                        . <br>
-                        . <br>
-                        . <br>
-                        19:00 <br>
-                        . <br>
-                        . <br>
-                        . <br>
-                        . <br>
-                        . <br>
-                        Late <br></b> </center>
-                        </td>
-                    <td>
-                              <br>
-                              <br>
-                             Guests beginning to arrive in Slane <br>
-                              <br>
-                              <br>
-                              <br>
-                            Check-in at The Millhouse (for guests choosing to stay onsite on Aug 27)
-                              <br>
-                              <br>
-                              <br>
-                              <br>
-                              <br>
-                            <b>Optional</b> casual social @ local pub in Slane for anyone in town<br>
-                              <br>
-                              <br>
+                    <td colspan="2" style="text-align:center;">
+                        <img src="icons/27august2025.png" alt="August 27 schedule icon" style="width: 200px; margin-right: 5px; vertical-align: middle;">
                     </td>
                 </tr>
-                <tr><td><center><img src="icons/28august2025.png" alt="August 28 schedule icon"
-                    style="width: 200px; margin-right: 5px; vertical-align: middle;"></center></td></tr>
-                <tr><td><center> <b>
-                    Early <br>
-                   . <br>
-                   . <br>
-                   . <br>
-                   15:00 <br>
-                   . <br>
-                   . <br>
-                   . <br>
-                   . <br>
-                   15:30 <br>
-                   . <br>
-                   . <br>
-                   . <br>
-                   16:00 <br>
-                   . <br>
-                   . <br>
-                   . <br>
-                   18:00 <br>
-                   . <br>
-                   . <br>
-                   . <br>
-                   . <br>
-                   . <br>
-                   Late <br></b>
-                </center>
-                   </td> 
-                
-
-                   <td><br>
-                     <br>
-                   Free time to explore and do your thing!
-                     <br>
-                     <br>
-                     <br>
-                     <br>
-                     Guests beginning to arrive at The Millhouse to attend the wedding <br>
-                     Check-in at The Millhouse (for guests only staying onsite night of the wedding)<br>
-                     <br>
-                     <br>
-                     <br>
-                   Wedding Ceremony<br>
-                     <br>
-                     <br>
-                     <br>
-                    Drinks Reception <br>
-                     <br>
-                     <br>
-                     <br>
-                     <br>
-                    Dinner Reception & lots of dancing! <br>
-                     <br>
-                     <br>
-                   </td> 
-                
+                <tr>
+                    <td><b>Early</b></td>
+                    <td>Guests beginning to arrive in Slane</td>
                 </tr>
-
-
-
-            
-            </table>
-        </div>
-    </section>
-            
-
-            
+                <tr>
+                    <td><b>15:00</b></td>
+                    <td>Check-in at The Millhouse (for guests choosing to stay onsite on Aug 27)</td>
+                </tr>
+                <tr>
+                    <td><b>19:00</b></td>
+                    <td><b>Optional</b> casual social @ local pub in Slane for anyone in town</td>
+                </tr>
+                <tr>
+                    <td colspan="2" style="text-align:center;">
+                        <img src="icons/28august2025.png" alt="August 28 schedule icon" style="width: 200px; margin-right: 5px; vertical-align: middle;">
+                    </td>
+                </tr>
+                <tr>
+                    <td><b>Early</b></td>
+                    <td>Free time to explore and do your thing!</td>
+                </tr>
+                <tr>
+                    <td><b>15:00</b></td>
+                    <td>Guests beginning to arrive at The Millhouse to attend the wedding</td>
+                </tr>
+                <tr>
+                    <td><b>15:30</b></td>
+                    <td>Check-in at The Millhouse (for guests only staying onsite night of the wedding)</td>
+                </tr>
+                <tr>
+                    <td><b>16:00</b></td>
+                    <td>Wedding Ceremony</td>
+                </tr>
+                <tr>
+                    <td><b>18:00</b></td>
+                    <td>Drinks Reception</td>
+                </tr>
+                <tr>
+                    <td><b>Late</b></td>
+                    <td>Dinner Reception & lots of dancing!</td>
+                </tr>
             </table>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- format events schedule as a table with proper rows
- remove extra markup so times align with descriptions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684c83d7f7e08329b1cb97fc9b8b686b