### PR TITLE
Update footer navigation

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -6,8 +6,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const buttons = [
         { text: 'Our Story', handler: () => navigateAndShow('our-story') },
         { text: 'Venue', handler: () => navigateAndShow('venue-details') },
-        { text: 'Save the Date', handler: () => navigateAndShow('save-date') },
-        { text: 'RSVP', handler: () => { location.href = 'rsvp.html'; } }
+        { text: 'Schedule of Events', handler: () => { location.href = 'events.html'; } }
     ];
 
     buttons.forEach(info => {
@@ -52,19 +51,6 @@ function showContent(section) {
         </div>
         
         `;
-    } else if (section === 'save-date') {
-        content = `
-        <div class="centered-image">
-        <div style="text-align: center; margin-top: 20px;">
-        <a href="data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ASUMMARY:Lucy+%26+Logan%27s+Wedding%0ADTSTART:20250827T000000Z%0ADTEND:20250828T235900Z%0ADESCRIPTION:Save+the+date+for+Lucy+%26+Logan%27s+wedding+from+August+27+-+28,+2025.+Can%27t+wait+to+celebrate+with+you!%0ALOCATION:The+Millhouse,+Slane,+Co.+Meath,+Ireland%0AEND:VEVENT%0AEND:VCALENDAR" 
-            download="Lucy_and_Logan_Wedding.ics"
-            style="text-decoration: none;">
-            <img src="img/savethedate.png" alt="Save the Date">
-        </a>
-        </div>
-        </div>
-        `;
-
     } else if (section === 'contact') {
         content = `
             <div class="centered-image">


### PR DESCRIPTION
## Summary
- remove Save the Date and RSVP from footer menu
- add Schedule of Events link in footer that directs to existing events page
- drop unused Save the Date content from footer script

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d4a35642c832990f8f951a7f607ba