### PR TITLE
Remove header placeholder from events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -11,10 +11,8 @@
 </head>
 
 <body>
-    <!-- Top Header with Navigation Links -->
-
-      <!-- Main Content Section -->
-      <section id="main-content">
+    <!-- Main Content Section -->
+    <section id="main-content">
         <div class="content-container">
             <h2 style="text-align: center; color: #538F9F; font-size: larger;">Schedule & Events</h2>
             <table class="content-table">


### PR DESCRIPTION
## Summary
- Remove leftover header placeholder from events page to ensure header is fully removed

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d4d1e86988329bdb42dfc5c0f834f