### PR TITLE
Adjust event schedule times

### DIFF
--- a/events.html
+++ b/events.html
@@ -29,7 +29,7 @@
                     <td>Guests beginning to arrive in Slane</td>
                 </tr>
                 <tr>
-                    <td><b>15:00</b></td>
+                    <td><b>16:00 - 18:00</b></td>
                     <td>Check-in at The Millhouse (for guests choosing to stay onsite on Aug 27)</td>
                 </tr>
                 <tr>
@@ -46,23 +46,23 @@
                     <td>Free time to explore and do your thing!</td>
                 </tr>
                 <tr>
-                    <td><b>15:00</b></td>
+                    <td><b>14:45</b></td>
                     <td>Guests beginning to arrive at The Millhouse to attend the wedding</td>
                 </tr>
                 <tr>
-                    <td><b>15:30</b></td>
-                    <td>Check-in at The Millhouse (for guests only staying onsite night of the wedding)</td>
-                </tr>
-                <tr>
-                    <td><b>16:00</b></td>
+                    <td><b>15:00</b></td>
                     <td>Wedding Ceremony</td>
                 </tr>
                 <tr>
-                    <td><b>18:00</b></td>
+                    <td><b>16:00</b></td>
                     <td>Drinks Reception</td>
                 </tr>
                 <tr>
-                    <td><b>Late</b></td>
+                    <td><b>16:00 - 18:00</b></td>
+                    <td>Check-in at The Millhouse (for guests only staying onsite night of the wedding)</td>
+                </tr>
+                <tr>
+                    <td><b>18:00</b></td>
                     <td>Dinner Reception & lots of dancing!</td>
                 </tr>
             </table>


### PR DESCRIPTION
## Summary
- Update August 27 check-in window to 16:00-18:00
- Revise August 28 timeline with new arrival, ceremony, drinks, check-in, and dinner times in chronological order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d508e10488329af25ac573832e24b