### PR TITLE
Restore previous header menu styling

### DIFF
--- a/header.js
+++ b/header.js
@@ -3,21 +3,46 @@
 
 document.addEventListener('DOMContentLoaded', function () {
     const header = document.createElement('header');
-    header.className = 'main-header';
+    header.className = 'top-header';
 
-    const nav = document.createElement('nav');
+    const desktopNav = document.createElement('nav');
+    desktopNav.className = 'desktop-nav';
 
-    const homeLink = document.createElement('a');
-    homeLink.href = 'index.html';
-    homeLink.textContent = 'Home';
+    const links = [
+        { href: 'travel.html', text: 'Travel' },
+        { href: 'accommodation.html', text: 'Accommodation' },
+        { href: 'index.html', text: 'Home' },
+        { href: 'photos.html', text: 'Photos' },
+        { href: 'events.html', text: 'Schedule/Events' },
+        { href: 'faqs.html', text: 'FAQs' },
+        { href: 'gifts.html', text: 'Gifts & Thanks' }
+    ];
 
-    const photosLink = document.createElement('a');
-    photosLink.href = 'photos.html';
-    photosLink.textContent = 'Photos';
+    links.forEach(link => {
+        const anchor = document.createElement('a');
+        anchor.href = link.href;
+        anchor.textContent = link.text;
+        desktopNav.appendChild(anchor);
+    });
 
-    nav.appendChild(homeLink);
-    nav.appendChild(photosLink);
-    header.appendChild(nav);
+    const mobileMenu = document.createElement('select');
+    mobileMenu.className = 'mobile-menu';
+    mobileMenu.addEventListener('change', function () {
+        location = this.value;
+    });
+
+    links.forEach(link => {
+        const option = document.createElement('option');
+        option.value = link.href;
+        option.textContent = link.text;
+        if (link.href === 'index.html') {
+            option.selected = true;
+        }
+        mobileMenu.appendChild(option);
+    });
+
+    header.appendChild(desktopNav);
+    header.appendChild(mobileMenu);
 
     // Insert header at the top of the body
     document.body.prepend(header);

--- a/styles.css
+++ b/styles.css
@@ -31,28 +31,53 @@ body, html {
     font-style: normal;
 }
 
-/* Header Navigation */
-.main-header {
+/* Header Styles */
+.top-header {
     position: fixed;
     top: 0;
     width: 100%;
-    background: rgba(255, 255, 255, 0.9);
-    padding: 20px 0;
     text-align: center;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    padding: 20px;
+    background-color: #efefef;
     z-index: 1000;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
 }
 
-.main-header nav a {
-    margin: 0 15px;
-    color: #4C945D;
+.top-header a {
+    margin: 0 20px;
+    color: #538F9F;
     text-decoration: none;
-    font-family: 'NySerif BItalic', sans-serif;
-    font-size: larger;
+    font-family: 'NySerif Bold', sans-serif;
+    font-size: large;
 }
 
-.main-header nav a:hover {
+.top-header a:hover {
     text-decoration: underline;
+}
+
+.desktop-nav {
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+}
+
+.mobile-menu {
+    display: none;
+    width: 100%;
+    font-size: 16px;
+    padding: 10px;
+}
+
+@media (max-width: 768px) {
+    .desktop-nav {
+        display: none;
+    }
+
+    .mobile-menu {
+        display: block;
+    }
 }
 
 /* Main Content Styling */


### PR DESCRIPTION
## Summary
- Reintroduce original top-header navigation with mobile dropdown
- Style header to match previous colour scheme and layout

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d52eb33588329937bf47c4af60779