### PR TITLE
Remove outdated schedule notice from events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -18,9 +18,6 @@
             <h2 style="text-align: center; color: #538F9F; font-size: larger;">Schedule & Events</h2>
             <table class="content-table">
                 <tr>
-                    <th colspan="2">The Schedule & Events page will continue to be updated as we get closer to the wedding date. In the meantime, see below for a high level breakdown of the celebrations.</th>
-                </tr>
-                <tr>
                     <td colspan="2" style="text-align:center;">
                         <img src="icons/27august2025.png" alt="August 27 schedule icon" style="width: 200px; margin-right: 5px; vertical-align: middle;">
                     </td>


### PR DESCRIPTION
## Summary
- remove outdated message about updating the schedule

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d5a7849a08329ac778cfcbb581b10